### PR TITLE
Improve model management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.6.21'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11

--- a/sample/src/main/java/org/imaginativeworld/whynotimagecarousel/sample/KotlinActivity.kt
+++ b/sample/src/main/java/org/imaginativeworld/whynotimagecarousel/sample/KotlinActivity.kt
@@ -364,11 +364,12 @@ class KotlinActivity : AppCompatActivity() {
 
         val listFive = mutableListOf<CarouselItem>()
 
+
         for (item in DataSet.five) {
             listFive.add(
                 CarouselItem(
-                    imageDrawable = item.first,
-                    caption = item.second
+                    item.first,
+                    item.second
                 )
             )
         }
@@ -423,7 +424,7 @@ class KotlinActivity : AppCompatActivity() {
         val listSix = mutableListOf<CarouselItem>()
 
         for (item in DataSet.six) {
-            listSix.add(CarouselItem())
+            listSix.add(CarouselItem(item.second))
         }
 
         binding.carousel6.setData(listSix)

--- a/sample/src/main/res/layout/fragment_sample.xml
+++ b/sample/src/main/res/layout/fragment_sample.xml
@@ -7,6 +7,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="#eee"
+        android:id="@+id/main"
         tools:context=".SampleFragment">
 
         <TextView

--- a/whynotimagecarousel/build.gradle
+++ b/whynotimagecarousel/build.gradle
@@ -1,18 +1,16 @@
 buildscript {
     repositories {
+        google()
         mavenCentral()
     }
-    dependencies {
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.19.0'
-        classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.6.10'
-    }
 }
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
-apply plugin: "com.vanniktech.maven.publish"
-apply plugin: "org.jetbrains.dokka"
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'kotlin-kapt'
+    id "org.jetbrains.dokka" version "1.6.21"
+    id 'maven-publish'
+}
 
 android {
     compileSdkVersion 31
@@ -61,4 +59,18 @@ dependencies {
 
     // Circle Indicator
     implementation 'me.relex:circleindicator:2.1.6'
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                from components.release
+
+                groupId = 'com.github.simoneraffaelli'
+                artifactId = 'Why-Not-Image-Carousel'
+                version = '0.0.0'
+            }
+        }
+    }
 }

--- a/whynotimagecarousel/build.gradle
+++ b/whynotimagecarousel/build.gradle
@@ -66,10 +66,8 @@ afterEvaluate {
         publications {
             release(MavenPublication) {
                 from components.release
-
                 groupId = 'com.github.simoneraffaelli'
                 artifactId = 'Why-Not-Image-Carousel'
-                version = '0.0.0'
             }
         }
     }

--- a/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/ImageCarousel.kt
+++ b/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/ImageCarousel.kt
@@ -23,24 +23,16 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.LinearSnapHelper
-import androidx.recyclerview.widget.PagerSnapHelper
-import androidx.recyclerview.widget.RecyclerView
-import androidx.recyclerview.widget.SnapHelper
+import androidx.recyclerview.widget.*
 import me.relex.circleindicator.CircleIndicator2
 import org.imaginativeworld.whynotimagecarousel.adapter.FiniteCarouselAdapter
 import org.imaginativeworld.whynotimagecarousel.adapter.InfiniteCarouselAdapter
 import org.imaginativeworld.whynotimagecarousel.listener.CarouselListener
 import org.imaginativeworld.whynotimagecarousel.listener.CarouselOnScrollListener
 import org.imaginativeworld.whynotimagecarousel.model.CarouselGravity
-import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
 import org.imaginativeworld.whynotimagecarousel.model.CarouselType
-import org.imaginativeworld.whynotimagecarousel.utils.CarouselLinearLayoutManager
-import org.imaginativeworld.whynotimagecarousel.utils.LinearStartSnapHelper
-import org.imaginativeworld.whynotimagecarousel.utils.dpToPx
-import org.imaginativeworld.whynotimagecarousel.utils.getSnapPosition
-import org.imaginativeworld.whynotimagecarousel.utils.spToPx
+import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
+import org.imaginativeworld.whynotimagecarousel.utils.*
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.Nullable
 
@@ -635,17 +627,17 @@ class ImageCarousel(
                 ).toInt()
 
                 carouselType = carouselTypeArray[
-                    getInteger(
-                        R.styleable.ImageCarousel_carouselType,
-                        CarouselType.BLOCK.ordinal
-                    )
+                        getInteger(
+                            R.styleable.ImageCarousel_carouselType,
+                            CarouselType.BLOCK.ordinal
+                        )
                 ]
 
                 carouselGravity = carouselGravityArray[
-                    getInteger(
-                        R.styleable.ImageCarousel_carouselGravity,
-                        CarouselGravity.CENTER.ordinal
-                    )
+                        getInteger(
+                            R.styleable.ImageCarousel_carouselGravity,
+                            CarouselGravity.CENTER.ordinal
+                        )
                 ]
 
                 showIndicator = getBoolean(
@@ -659,10 +651,10 @@ class ImageCarousel(
                 ).toInt()
 
                 imageScaleType = scaleTypeArray[
-                    getInteger(
-                        R.styleable.ImageCarousel_imageScaleType,
-                        ImageView.ScaleType.CENTER_CROP.ordinal
-                    )
+                        getInteger(
+                            R.styleable.ImageCarousel_imageScaleType,
+                            ImageView.ScaleType.CENTER_CROP.ordinal
+                        )
                 ]
 
                 carouselBackground = getDrawable(

--- a/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/adapter/FiniteCarouselAdapter.kt
+++ b/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/adapter/FiniteCarouselAdapter.kt
@@ -11,8 +11,8 @@ import androidx.viewbinding.ViewBinding
 import org.imaginativeworld.whynotimagecarousel.databinding.ItemCarouselBinding
 import org.imaginativeworld.whynotimagecarousel.listener.CarouselListener
 import org.imaginativeworld.whynotimagecarousel.model.CarouselGravity
-import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
 import org.imaginativeworld.whynotimagecarousel.model.CarouselType
+import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
 import org.imaginativeworld.whynotimagecarousel.utils.CarouselItemDecoration
 import org.imaginativeworld.whynotimagecarousel.utils.setImage
 

--- a/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/adapter/InfiniteCarouselAdapter.kt
+++ b/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/adapter/InfiniteCarouselAdapter.kt
@@ -5,8 +5,8 @@ import android.widget.ImageView
 import androidx.recyclerview.widget.RecyclerView
 import org.imaginativeworld.whynotimagecarousel.ImageCarousel
 import org.imaginativeworld.whynotimagecarousel.model.CarouselGravity
-import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
 import org.imaginativeworld.whynotimagecarousel.model.CarouselType
+import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
 
 class InfiniteCarouselAdapter(
     recyclerView: RecyclerView,

--- a/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/model/CarouselItem.kt
+++ b/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/model/CarouselItem.kt
@@ -1,58 +1,62 @@
 package org.imaginativeworld.whynotimagecarousel.model
 
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
 import androidx.annotation.DrawableRes
 
-data class CarouselItem constructor(
-    val imageUrl: String? = null,
-    @DrawableRes val imageDrawable: Int? = null,
+class CarouselItem private constructor(
+    internal val imageType: CarouselItemImage<*>,
     val caption: String? = null,
-    val headers: Map<String, String>?
+    val headers: Map<String, String>? = null
 ) {
-    constructor() : this(null, null, null, null)
-
-    constructor(imageUrl: String? = null) : this(
-        imageUrl,
-        null,
-        null,
-        null
-    )
-
-    constructor(imageUrl: String? = null, headers: Map<String, String>? = null) : this(
-        imageUrl,
-        null,
-        null,
-        headers
-    )
-
-    constructor(@DrawableRes imageDrawable: Int? = null) : this(
-        null,
-        imageDrawable,
-        null,
-        null
-    )
-
-    constructor(imageUrl: String? = null, caption: String? = null) : this(
-        imageUrl,
-        null,
-        caption,
-        null
-    )
+    val image = imageType.image
 
     constructor(
-        imageUrl: String? = null,
+        drawable: Drawable,
         caption: String? = null,
         headers: Map<String, String>? = null
     ) : this(
-        imageUrl,
-        null,
-        caption,
-        headers
+        imageType = DrawableImageType(image = drawable),
+        caption = caption,
+        headers = headers
     )
 
-    constructor(@DrawableRes imageDrawable: Int? = null, caption: String? = null) : this(
-        null,
-        imageDrawable,
-        caption,
-        null
+    constructor(
+        @DrawableRes drawableRes: Int,
+        caption: String? = null,
+        headers: Map<String, String>? = null
+    ) : this(
+        imageType = DrawableResImageType(image = drawableRes),
+        caption = caption,
+        headers = headers
+    )
+
+    constructor(
+        bitmap: Bitmap,
+        caption: String? = null,
+        headers: Map<String, String>? = null
+    ) : this(
+        imageType = BitmapImageType(image = bitmap),
+        caption = caption,
+        headers = headers
+    )
+
+    constructor(
+        imageUrl: String,
+        caption: String? = null,
+        headers: Map<String, String>? = null
+    ) : this(
+        imageType = UrlImageType(image = imageUrl),
+        caption = caption,
+        headers = headers
+    )
+
+    constructor(
+        caption: String,
+        headers: Map<String, String>? = null
+    ) : this(
+        imageType = StringCaptionImageType(image = caption),
+        caption = caption,
+        headers = headers
     )
 }

--- a/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/model/CarouselItemImage.kt
+++ b/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/model/CarouselItemImage.kt
@@ -1,0 +1,13 @@
+package org.imaginativeworld.whynotimagecarousel.model
+
+import android.graphics.Bitmap
+import android.graphics.drawable.Drawable
+import androidx.annotation.DrawableRes
+
+sealed class CarouselItemImage<T>(val image: T)
+
+class DrawableImageType(image: Drawable): CarouselItemImage<Drawable>(image)
+class DrawableResImageType(@DrawableRes image: Int): CarouselItemImage<Int>(image)
+class BitmapImageType(image: Bitmap): CarouselItemImage<Bitmap>(image)
+class UrlImageType(image: String): CarouselItemImage<String>(image)
+class StringCaptionImageType(image: String): CarouselItemImage<String>(image)

--- a/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/utils/Extensions.kt
+++ b/whynotimagecarousel/src/main/java/org/imaginativeworld/whynotimagecarousel/utils/Extensions.kt
@@ -12,8 +12,8 @@ import androidx.annotation.DrawableRes
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SnapHelper
 import com.bumptech.glide.Glide
-import com.bumptech.glide.load.model.GlideUrl
-import org.imaginativeworld.whynotimagecarousel.model.CarouselItem
+import com.bumptech.glide.RequestBuilder
+import org.imaginativeworld.whynotimagecarousel.model.*
 
 /**
  * This method converts device specific pixels to density independent pixels.
@@ -58,88 +58,38 @@ fun SnapHelper.getSnapPosition(layoutManager: RecyclerView.LayoutManager?): Int 
     return layoutManager.getPosition(snapView)
 }
 
-/**
- * Set image to the carouse image view.
- *
- * @param item The carousel item.
- */
-fun ImageView.setImage(item: CarouselItem) {
-    this.setImage(
-        item = item,
-        placeholderDrawable = null,
-        placeholderDrawableResourceId = null,
-    )
+private fun loadImage(ctx: Context, item: CarouselItem): RequestBuilder<*>? {
+    val glide = Glide.with(ctx.applicationContext)
+    return when (item.imageType) {
+        is DrawableImageType -> glide.load(item.image)
+        is BitmapImageType -> glide.load(item.image)
+        is DrawableResImageType -> glide.load(item.image)
+        is UrlImageType -> glide.load(item.image)
+        is StringCaptionImageType -> null
+    }
 }
 
-/**
- * Set image to the carouse image view.
- *
- * @param item The carousel item.
- * @param placeholderDrawableResourceId The id of the resource to use as a placeholder.
- */
+fun ImageView.setImage(
+    item: CarouselItem
+) {
+    loadImage(context, item)
+        ?.into(this)
+}
+
 fun ImageView.setImage(
     item: CarouselItem,
-    @DrawableRes placeholderDrawableResourceId: Int
+    @DrawableRes placeholderRes: Int
 ) {
-    this.setImage(
-        item = item,
-        placeholderDrawable = null,
-        placeholderDrawableResourceId = placeholderDrawableResourceId,
-    )
+    loadImage(context, item)
+        ?.placeholder(placeholderRes)
+        ?.into(this)
 }
 
-/**
- * Set image to the carouse image view.
- *
- * @param item The carousel item.
- * @param placeholderDrawable The drawable to display as a placeholder.
- */
 fun ImageView.setImage(
     item: CarouselItem,
-    placeholderDrawable: Drawable? = null,
+    placeholder: Drawable
 ) {
-    this.setImage(
-        item = item,
-        placeholderDrawable = placeholderDrawable,
-        placeholderDrawableResourceId = null,
-    )
-}
-
-/**
- * Set image to the carouse image view.
- *
- * @param item The carousel item.
- * @param placeholderDrawable The drawable to display as a placeholder.
- * @param placeholderDrawableResourceId The id of the resource to use as a placeholder.
- */
-private fun ImageView.setImage(
-    item: CarouselItem,
-    placeholderDrawable: Drawable? = null,
-    @DrawableRes placeholderDrawableResourceId: Int? = null
-) {
-    val glide = Glide.with(context.applicationContext)
-
-    var requestBuilder = when {
-        item.imageUrl != null && item.headers == null -> {
-            glide.load(item.imageUrl)
-        }
-        item.headers != null -> {
-            glide.load(GlideUrl(item.imageUrl.toString()) { item.headers })
-        }
-        else -> {
-            glide.load(item.imageDrawable)
-        }
-    }
-
-    requestBuilder = when {
-        placeholderDrawable != null -> {
-            requestBuilder.placeholder(placeholderDrawable)
-        }
-        placeholderDrawableResourceId != null -> {
-            requestBuilder.placeholder(placeholderDrawableResourceId)
-        }
-        else -> requestBuilder
-    }
-
-    requestBuilder.into(this)
+    loadImage(context, item)
+        ?.placeholder(placeholder)
+        ?.into(this)
 }


### PR DESCRIPTION
This pr allow the user to use bitmap as image type and, i think, it maked easier to add further image types in future.
Notable changes: now CarouseulItem has a image model semi generic dependent on the sealed class CarouselItemImage

I also removed com.vanniktech:gradle-maven-publish-plugin and added maven publishing so you need to changes the build.gradle to adapt the library.

Let me know if this can be a usefull approach

ty