### PR TITLE
Fixed Grammatical Error in Library Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ So it is recommended if you enabled `autoPlay` & `infiniteCarousel`.
 
 [image]
 
-The library is now supported infinite carousel. An infinite carousel means looping the item view infinitely. This feature is enabled by default. You can disable it by setting `infiniteCarousel` to `false`.
+The library now supports an infinite carousel, which means that the item view is looped infinitely. This feature is enabled by default, but you can disable it by setting the `infiniteCarousel` property to `false`.
 
 ## Indicator
 


### PR DESCRIPTION
Fixes #96 : The incorrect wording "The library is now supported infinite carousel" has been corrected to accurately reflect the functionality of the feature. This correction will improve the clarity of the documentation and provide a better user experience.